### PR TITLE
frontend: 用途説明と選択肢の最終反映（issue #25）

### DIFF
--- a/frontend/src/ResultView.tsx
+++ b/frontend/src/ResultView.tsx
@@ -234,7 +234,7 @@ export function ResultView({ config, onBack }: ResultProps) {
     });
   };
 
-  const IGPU_USAGES = new Set(["business", "standard"]);
+  const IGPU_USAGES = new Set(["general", "business", "standard"]);
 
   const normalizedParts: NormalizedResultPart[] = isSavedConfiguration(config)
     ? (() => {
@@ -529,7 +529,7 @@ export function ResultView({ config, onBack }: ResultProps) {
     gaming: "ゲーミングPC",
     creator: "クリエイターPC",
     ai: "AI PC（ローカルAI）",
-    general: "汎用PC",
+    general: "汎用PC（事務・学習向け）",
   };
   const usageCode = normalizeUsageCode(config.usage);
   const usageLabel = USAGE_LABELS[usageCode] ?? usageCode;


### PR DESCRIPTION
## 概要
- フロントの用途表示を要件定義に合わせて最終整合
- 汎用用途ラベルを『汎用PC（事務・学習向け）』へ統一
- 保存済み構成の iGPU 判定に general を追加

## 変更ファイル
- frontend/src/ResultView.tsx

## issue
- closes #25